### PR TITLE
Steps should have a unit of 'steps'

### DIFF
--- a/custom_components/tryfi/sensor.py
+++ b/custom_components/tryfi/sensor.py
@@ -177,7 +177,7 @@ class PetStatsSensor(CoordinatorEntity, Entity):
         if self.statType.upper() == "DISTANCE":
             return LENGTH_KILOMETERS
         else:
-            return None
+            return "steps"
 
     @property
     def device_info(self):


### PR DESCRIPTION
This will allow charting the values over time. Per https://www.home-assistant.io/lovelace/history-graph/ sensors need a unit of measurement for the history card to show a a graph instead of a single horizontal bar.