### PR TITLE
Feature: Battery Charging Sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Current functionality includes:
 * Step Counter - it will report your pets daily, weekly, and monthly steps
 * Distance Counter - it will report your pets daily, weekly and monthly distance
 * Battery Level - it will report your Pet's collar battery level
+* Battery Charging - it will report if your Pet's collar is charging
 * Collar Light - you can control the light on the collar by turning it on and off (color selection coming soon!)
 * Lost Dog Mode - allows you to select Lost mode if your dog if it is lost and select Safe if it is found
 * Bases - reports the status of the base (online/offline)
@@ -85,6 +86,7 @@ type: entities
 entities:
   - entity: select.harley_lost_state
   - entity: sensor.harley_collar_battery_level
+  - entity: binary_sensor.harley_collar_battery_charging
   - entity: sensor.home_base
   - entity: sensor.harley_daily_steps
   - entity: sensor.harley_weekly_steps
@@ -130,7 +132,31 @@ Turns on the collar light after dark if the pet is not home.
     domain: light
   mode: single
 ```
-
+## Fully Charged Notification
+Sends notification when battery has charged to 100%.
+```
+- id: '1661129896868'
+  alias: Pet's Collar - Fully Charged
+  description: ''
+  trigger:
+  - platform: state
+    entity_id:
+    - sensor.pet_collar_battery_level
+    to: '100'
+    for:
+      hours: 0
+      minutes: 0
+      seconds: 0
+  condition:
+  - condition: state
+    entity_id: binary_sensor.pet_collar_battery_charging
+    state: 'on'
+  action:
+  - service: notify.everyone_phone
+    data:
+      message: Pet's collar is fully charged!
+  mode: single
+```
 # Known Issues
 * It sometimes takes time for the status to accurately refresh in HA. For example the light on/off status and the Lost Mode select status.
 

--- a/custom_components/tryfi/binary_sensor.py
+++ b/custom_components/tryfi/binary_sensor.py
@@ -5,7 +5,6 @@ from homeassistant.components.binary_sensor import (
     DEVICE_CLASS_BATTERY_CHARGING,
 )
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
-from homeassistant.helpers.icon import icon_for_battery_level
 
 from .const import DOMAIN
 

--- a/custom_components/tryfi/binary_sensor.py
+++ b/custom_components/tryfi/binary_sensor.py
@@ -1,0 +1,91 @@
+import logging
+
+from homeassistant.components.binary_sensor import (
+    BinarySensorEntity,
+    DEVICE_CLASS_BATTERY_CHARGING,
+)
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.helpers.icon import icon_for_battery_level
+
+from .const import DOMAIN
+
+LOGGER = logging.getLogger(__name__)
+
+async def async_setup_entry(hass, config_entry, async_add_devices):
+    """Add binary sensors for passed config_entry in HA."""
+    coordinator = hass.data[DOMAIN][config_entry.entry_id]
+
+    tryfi = coordinator.data
+
+    new_devices = []
+    for pet in tryfi.pets:
+        LOGGER.debug(f"Adding Pet Battery Charging Binary Sensor: {pet}")
+        new_devices.append(TryFiBatteryChargingBinarySensor(hass, pet, coordinator))
+    if new_devices:
+        async_add_devices(new_devices)
+
+class TryFiBatteryChargingBinarySensor(CoordinatorEntity, BinarySensorEntity):
+    """Representation of a Binary Sensor."""
+
+    def __init__(self, hass, pet, coordinator):
+        self._hass = hass
+        self._petId = pet.petId
+        super().__init__(coordinator)
+
+    @property
+    def name(self):
+        """Return the name of the binary sensor."""
+        return f"{self.pet.name} Collar Battery Charging"
+
+    @property
+    def unique_id(self):
+        """Return the ID of this sensor."""
+        return f"{self.pet.petId}-battery-charging"
+
+    @property
+    def petId(self):
+        return self._petId
+
+    @property
+    def pet(self):
+        return self.coordinator.data.getPet(self.petId)
+
+    @property
+    def device(self):
+        return self.pet.device
+
+    @property
+    def device_id(self):
+        return self.unique_id
+
+    @property
+    def device_class(self):
+        """Return the device class of the binary sensor."""
+        return DEVICE_CLASS_BATTERY_CHARGING
+
+    @property
+    def isCharging(self):
+        return bool(self.pet.device.isCharging)
+
+    @property
+    def icon(self):
+        """Return the icon for charging."""
+        if self.isCharging:
+            return "mdi:power-plug"
+        else:
+            return "mdi:power-plug-off"
+
+    @property
+    def is_on(self):
+        """Return the state of the binary sensor"""
+        return self.isCharging
+
+    @property
+    def device_info(self):
+        return {
+            "identifiers": {(DOMAIN, self.pet.petId)},
+            "name": self.pet.name,
+            "manufacturer": "TryFi",
+            "model": self.pet.breed,
+            "sw_version": self.pet.device.buildId,
+        }

--- a/custom_components/tryfi/const.py
+++ b/custom_components/tryfi/const.py
@@ -1,5 +1,5 @@
 DOMAIN = "tryfi"
-PLATFORMS = ["device_tracker", "light", "sensor", "select"]
+PLATFORMS = ["device_tracker", "light", "sensor", "select", "binary_sensor"]
 DEFAULT_POLLING_RATE = "10"
 CONF_POLLING_RATE = "polling"
 CONF_USERNAME = "username"


### PR DESCRIPTION
Added a new binary sensor that reports if the collar is charging or not.

I have a notification that lets me know when my pet's collar is fully charged. Unfortunately, the battery level bounces between 99% and 100% for the first couple hours it's off the charger. This results in a notification each time it reports 100%. The new charging sensor allows you to only send a notification when the level reports 100% AND it reports that it's charging.

Just thought of another alert as I'm typing. This would also allow you to send an alert reminding you that your pet doesn't have their collar on if the collar is charging and you open the back door to let them outside.