### PR TITLE
Add collar color selection and Dev Container support

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,0 +1,40 @@
+{
+    "name": "TryFi Dev Container",
+    "image": "mcr.microsoft.com/devcontainers/python:3.11-bullseye",
+    "postCreateCommand": "scripts/setup",
+    "forwardPorts": [
+        8123
+    ],
+    "portsAttributes": {
+        "8123": {
+            "label": "Home Assistant",
+            "onAutoForward": "notify"
+        }
+    },
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "ms-python.python",
+                "ms-python.vscode-pylance"
+            ],
+            "settings": {
+                "files.eol": "\n",
+                "editor.tabSize": 4,
+                "python.pythonPath": "/usr/bin/python3",
+                "python.analysis.autoSearchPaths": false,
+                "python.linting.pylintEnabled": true,
+                "python.linting.enabled": true,
+                "python.formatting.provider": "black",
+                "python.formatting.blackPath": "/usr/local/py-utils/bin/black",
+                "editor.formatOnPaste": false,
+                "editor.formatOnSave": true,
+                "editor.formatOnType": true,
+                "files.trimTrailingWhitespace": true
+            }
+        }
+    },
+    "remoteUser": "vscode",
+    "features": {
+        "ghcr.io/devcontainers/features/rust:1": {}
+    }
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,12 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Run Home Assistant on port 8123",
+            "type": "shell",
+            "command": "scripts/develop",
+            "problemMatcher": []
+        }
+
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![](https://img.shields.io/github/license/sbabcock23/hass-tryfi?style=for-the-badge)](LICENSE)
 [![](https://img.shields.io/github/workflow/status/sbabcock23/hass-tryfi/Validate%20with%20hassfest?style=for-the-badge)](https://github.com/sbabcock23/hass-tryfi/actions)
 
-This allows you to integrate [TryFi](https://tryfi.com) Smart GPS Collars with Home Assistant. 
+This allows you to integrate [TryFi](https://tryfi.com) Smart GPS Collars with Home Assistant.
 
 ## Features
 Current functionality includes:
@@ -15,7 +15,7 @@ Current functionality includes:
 * Distance Counter - it will report your pets daily, weekly and monthly distance
 * Battery Level - it will report your Pet's collar battery level
 * Battery Charging - it will report if your Pet's collar is charging
-* Collar Light - you can control the light on the collar by turning it on and off (color selection coming soon!)
+* Collar Light - you can control the light on the collar by turning it on and off and setting the color
 * Lost Dog Mode - allows you to select Lost mode if your dog if it is lost and select Safe if it is found
 * Bases - reports the status of the base (online/offline)
 
@@ -68,7 +68,8 @@ Once you have added the integration, you will see 1 or more devices and entities
 
 # How to Use
 ## Light Collar
-The light on your Pet's collar is represented as a light switch in HA. It can either be turned on or off. 
+The light on your Pet's collar is represented as a light switch in HA. It can either be turned on or off.
+The color can be set. The collar only supports Red, Green, Blue, LightBlue, Purple, Yellow, and White. The closest color to your selection will be used.
 
 ![Lovelace](https://github.com/sbabcock23/hass-tryfi/blob/master/docs/doglight.jpg?raw=true)
 
@@ -170,7 +171,7 @@ Sends notification when battery has charged to 100%.
 ## 0.0.20
 * Fix - Due to recent changes by TryFi, additional changes were required in the pytryfi library. Bumping version to include those changes/fixes.
 ## 0.0.19
-* Fix - pets without collars were causing errors. 
+* Fix - pets without collars were causing errors.
 ## 0.0.18
 * Enhancement - Battery Charging - it will report if your Pet's collar is charging
 ## 0.0.17

--- a/custom_components/tryfi/light.py
+++ b/custom_components/tryfi/light.py
@@ -1,27 +1,65 @@
 import logging
-from datetime import datetime, timedelta
 
-from homeassistant.components.light import SUPPORT_COLOR, LightEntity
-from homeassistant.const import (
-    DEVICE_CLASS_BATTERY,
-    PERCENTAGE,
-    STATE_OK,
-    STATE_PROBLEM,
-)
-from homeassistant.core import callback
-from homeassistant.helpers import device_registry as dr
-from homeassistant.helpers.dispatcher import async_dispatcher_connect, dispatcher_send
-from homeassistant.helpers.icon import icon_for_battery_level
+from homeassistant.components.light import LightEntity, ColorMode
 from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
-    DataUpdateCoordinator,
-    UpdateFailed,
 )
-from homeassistant.util import color
+import math
 
 from .const import DOMAIN
 
 LOGGER = logging.getLogger(__name__)
+
+# A map of RGB colors to their corresponding color code in the tryfi API
+# The RGB values are my best guess
+COLOR_MAP = {
+    2: [224, 79, 72], # Red
+    3: [89, 165, 51], # Green
+    4: [42,97,215], # Blue
+    5: [209,63,177], # Purple
+    6: [223,223,74], # Yellow
+    7: [98,210,210], # Light Blue
+    8: [255,255,255], # White
+}
+
+
+def calculate_distance(color1, color2):
+    """
+    Calculate Euclidean distance between two RGB colors.
+
+    Parameters:
+    - color1 (Tuple[int, int, int]): RGB values of the first color.
+    - color2 (Tuple[int, int, int]): RGB values of the second color.
+
+    Returns:
+    - float: The Euclidean distance between the two RGB colors.
+    """
+    return math.sqrt(sum((c1 - c2) ** 2 for c1, c2 in zip(color1, color2)))
+
+def find_closest_color_code(target_color , color_list):
+    """
+    Find the RGB color closest to the target color in a list.
+
+    Parameters:
+    - target_color (Tuple[int, int, int]): RGB values of the target color.
+    - color_list (Dict[Int: Tuple[int, int, int]]): Map of RGB colors to compare, where the key is the color code used by the device
+
+    Returns:
+    - int: The color code for this device closest to the target color
+    """
+    min_distance = float('inf')
+    closest_color = None  # type: Tuple[int, int, int]
+    # default to white, which is 8
+    closest_color_code = 8 # type: int
+
+    for code, color in color_list.items():
+        distance = calculate_distance(target_color, color)
+        if distance < min_distance:
+            min_distance = distance
+            closest_color_code = code
+
+    return closest_color_code
+
 
 
 async def async_setup_entry(hass, config_entry, async_add_devices):
@@ -40,9 +78,11 @@ async def async_setup_entry(hass, config_entry, async_add_devices):
 class TryFiPetLight(CoordinatorEntity, LightEntity):
     def __init__(self, hass, pet, coordinator):
         self._petId = pet.petId
-        # self._tryfi = tryfi
         self._hass = hass
-        # self._coordinator = coordinator
+
+        # PyTryFi does not have a getColor query so we just start at white
+        self.lastKnownColor = [255,255,255]
+
         super().__init__(coordinator)
 
     @property
@@ -73,13 +113,17 @@ class TryFiPetLight(CoordinatorEntity, LightEntity):
     def is_on(self):
         return bool(self.pet.device.ledOn)
 
-    # @property
-    # def hs_color(self):
-    #    colorObj = color(self.pet.device.ledColor)
-    #    return colorObj.hsl
-    # @property
-    # def supported_features(self):
-    #    return SUPPORT_COLOR
+    @property
+    def supported_color_modes(self):
+       return [ColorMode.RGB]
+
+    @property
+    def color_mode(self):
+       return ColorMode.RGB
+
+    @property
+    def rgb_light(self):
+        return self.lastKnownColor
 
     @property
     def device_info(self):
@@ -94,8 +138,15 @@ class TryFiPetLight(CoordinatorEntity, LightEntity):
     # Fix later, request update
     def turn_on(self, **kwargs):
         self.pet.turnOnOffLed(self.tryfi.session, True)
-        # self.coordinator.async_request_refresh()
+
+        if "rgb_color" in kwargs:
+            # This is set when the color is changed
+            # if the brightness(which is a no-op) is changed, for example, this is not set
+            requested_color = kwargs["rgb_color"]
+            closest_color_code = find_closest_color_code(requested_color, COLOR_MAP)
+
+            self.pet.setLedColorCode(self.tryfi.session, closest_color_code)
+            self.lastKnownColor = COLOR_MAP[closest_color_code]
 
     def turn_off(self, **kwargs):
         self.pet.turnOnOffLed(self.tryfi.session, False)
-        # self.coordinator.async_request_refresh()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+homeassistant==2023.12.0
+pip>=21.0,<23.2
+
+# Workaround for this issue: https://github.com/home-assistant/core/issues/95192
+botocore @ git+https://github.com/boto/botocore
+urllib3==1.26.16
+
+

--- a/scripts/develop
+++ b/scripts/develop
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+# Create config dir if not present
+if [[ ! -d "${PWD}/config" ]]; then
+    mkdir -p "${PWD}/config"
+    hass --config "${PWD}/config" --script ensure_config
+fi
+
+# Set the path to custom_components
+## This let's us have the structure we want <root>/custom_components/integration_blueprint
+## while at the same time have Home Assistant configuration inside <root>/config
+## without resulting to symlinks.
+export PYTHONPATH="${PYTHONPATH}:${PWD}/custom_components"
+
+# Start Home Assistant
+hass --config "${PWD}/config" --debug

--- a/scripts/setup
+++ b/scripts/setup
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+python3 -m pip install --requirement requirements.txt


### PR DESCRIPTION
I've added color support to the Collar light entity.

I manually mapped color codes for my dog's Fi3 color to RGB colors. From a HA perspective, the light supports RGB. Euclidean distance is used to find the closest supported color.

Brightness is not supported but HA expects this for all lights with color control so brightness is simply ignored.

Risks:
I have only tested this with FI3. It's possible other collars have other colors and could act in unexpected ways.

Alternatives considered:
The color matching may work unexpectedly  for users as the UI does not tell the user which colors are supported. Instead we could use an additional selection control or light effects in HA so the UI is more clear.

I've also added dev container support for VSCode. As this is a cloud-integration I find this a much easier way to test changes and it does not require messing with my actual HA instance