### PR TITLE
Fix silent setup errors with PyTryFi

### DIFF
--- a/custom_components/tryfi/__init__.py
+++ b/custom_components/tryfi/__init__.py
@@ -39,6 +39,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     tryfi = await hass.async_add_executor_job(PyTryFi,entry.data["username"], entry.data["password"])
     hass.data[DOMAIN][entry.entry_id] = tryfi
 
+    # Exceptions are swallowed in the PyTryFi library, so we must assert a 
+    # sucessful login before continuing with setup. When not successful,
+    # hass will continue to retry setup
+    if not hasattr(tryfi, 'currentUser'):
+        raise ConfigEntryNotReady
+
     coordinator = TryFiDataUpdateCoordinator(hass, tryfi, int(entry.data["polling"]))
     await coordinator.async_config_entry_first_refresh()
 

--- a/custom_components/tryfi/__init__.py
+++ b/custom_components/tryfi/__init__.py
@@ -40,10 +40,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data[DOMAIN][entry.entry_id] = tryfi
 
     coordinator = TryFiDataUpdateCoordinator(hass, tryfi, int(entry.data["polling"]))
-    await coordinator.async_refresh()
-
-    if not coordinator.last_update_success:
-        raise ConfigEntryNotReady
+    await coordinator.async_config_entry_first_refresh()
 
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.entry_id] = coordinator


### PR DESCRIPTION
This PR fixes a couple of silent async setup errors that could cause issues like `has no attribute _pets` and lead to unavailable entities.

With these changes, Home Assistant will report an error setting up the integration and periodically retry setup. Previously, the integration would finish setup, and all entities would show as unavailable.